### PR TITLE
feat: In broadcast history API, provide summary of image generation requests per-screening

### DIFF
--- a/db/migrations/009_screening_id.down.sql
+++ b/db/migrations/009_screening_id.down.sql
@@ -1,0 +1,6 @@
+begin;
+
+alter table showtime.screening
+    drop column id;
+
+commit;

--- a/db/migrations/009_screening_id.up.sql
+++ b/db/migrations/009_screening_id.up.sql
@@ -1,0 +1,22 @@
+begin;
+
+-- Add an ID column to the screening table, with no constraints initially
+alter table showtime.screening
+    add column id uuid;
+
+comment on column showtime.screening.id is
+    'Unique ID for this screening; used chiefly to associate other data with this '
+    'screening.';
+
+-- Add a random UUID to all existing screenings
+update showtime.screening set id = gen_random_uuid();
+
+-- Now that all of our existing screenings have an ID, make that column the primary key
+-- and establish a default value
+alter table showtime.screening
+    add primary key (id);
+
+alter table showtime.screening
+    alter column id set default gen_random_uuid();
+
+commit;

--- a/db/migrations/010_image_screening_id.down.sql
+++ b/db/migrations/010_image_screening_id.down.sql
@@ -1,0 +1,6 @@
+begin;
+
+alter table showtime.image_request
+    drop column screening_id;
+
+commit;

--- a/db/migrations/010_image_screening_id.up.sql
+++ b/db/migrations/010_image_screening_id.up.sql
@@ -1,0 +1,17 @@
+begin;
+
+alter table showtime.image_request
+    add column screening_id uuid;
+
+comment on column showtime.image_request.screening_id is
+    'ID of the screening that was active when the image request was submitted; may be '
+    'null if the request was submitted while no tape was active.';
+
+update showtime.image_request
+    set screening_id = (
+        select id from showtime.screening
+            where image_request.created_at between screening.started_at and screening.ended_at
+            limit 1
+    );
+
+commit;

--- a/db/queries/history.sql
+++ b/db/queries/history.sql
@@ -32,7 +32,7 @@ select
             where image_request.screening_id = screening.id
         ),
         '[]'::json
-    ) as image_requests
+    )::json as image_requests
 from showtime.screening
 where screening.broadcast_id = sqlc.arg('broadcast_id')
 order by screening.started_at;

--- a/db/queries/history.sql
+++ b/db/queries/history.sql
@@ -36,3 +36,17 @@ select
 from showtime.screening
 where screening.broadcast_id = sqlc.arg('broadcast_id')
 order by screening.started_at;
+
+-- name: GetViewerLookupForBroadcast :many
+select
+    viewer.twitch_user_id,
+    viewer.twitch_display_name
+from showtime.viewer
+where viewer.twitch_user_id in (
+    select distinct image_request.twitch_user_id
+    from showtime.image_request
+    where image_request.screening_id in (
+        select screening.id from showtime.screening
+        where screening.broadcast_id = sqlc.arg('broadcast_id')
+    )
+);

--- a/db/queries/history.sql
+++ b/db/queries/history.sql
@@ -17,7 +17,22 @@ where broadcast.id = sqlc.arg('broadcast_id');
 
 -- name: GetScreeningsByBroadcastId :many
 select
-    *
+    screening.tape_id,
+    screening.started_at,
+    screening.ended_at,
+    coalesce(
+        (
+            select json_agg(
+                json_build_object(
+                    'id', image_request.id,
+                    'twitch_user_id', twitch_user_id,
+                    'subject', subject_noun_clause
+                ))
+            from showtime.image_request
+            where image_request.screening_id = screening.id
+        ),
+        '[]'::json
+    ) as image_requests
 from showtime.screening
 where screening.broadcast_id = sqlc.arg('broadcast_id')
 order by screening.started_at;

--- a/db/queries/image.sql
+++ b/db/queries/image.sql
@@ -2,12 +2,14 @@
 insert into showtime.image_request (
     id,
     twitch_user_id,
+    screening_id,
     subject_noun_clause,
     prompt,
     created_at
 ) values (
     sqlc.arg('image_request_id'),
     sqlc.arg('twitch_user_id'),
+    sqlc.narg('screening_id'),
     sqlc.arg('subject_noun_clause'),
     sqlc.arg('prompt'),
     now()

--- a/db/queries/screening.sql
+++ b/db/queries/screening.sql
@@ -24,15 +24,14 @@ update showtime.screening set ended_at = now()
 where screening.broadcast_id = sqlc.arg('broadcast_id')
     and screening.ended_at is null;
 
--- name: GetCurrentTapeId :one
+-- name: GetCurrentScreening :one
 select
-    (case when screening.ended_at is null
-        then screening.tape_id
-        else null
-    end)::integer as tape_id
-from showtime.screening
-where screening.broadcast_id = (
-    select broadcast.id from showtime.broadcast
-    order by broadcast.started_at desc limit 1
-)
-order by screening.started_at desc limit 1;
+    screening.id::uuid as id,
+    screening.tape_id,
+    screening.started_at,
+    screening.ended_at
+from showtime.broadcast
+join showtime.screening
+    on screening.broadcast_id = broadcast.id
+order by screening.started_at desc, broadcast.started_at desc
+limit 1;

--- a/gen/queries/history.sql.go
+++ b/gen/queries/history.sql.go
@@ -8,6 +8,7 @@ package queries
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/lib/pq"
@@ -44,7 +45,7 @@ select
             where image_request.screening_id = screening.id
         ),
         '[]'::json
-    ) as image_requests
+    )::json as image_requests
 from showtime.screening
 where screening.broadcast_id = $1
 order by screening.started_at
@@ -54,7 +55,7 @@ type GetScreeningsByBroadcastIdRow struct {
 	TapeID        int32
 	StartedAt     time.Time
 	EndedAt       sql.NullTime
-	ImageRequests interface{}
+	ImageRequests json.RawMessage
 }
 
 func (q *Queries) GetScreeningsByBroadcastId(ctx context.Context, broadcastID int32) ([]GetScreeningsByBroadcastIdRow, error) {

--- a/gen/queries/image.sql.go
+++ b/gen/queries/image.sql.go
@@ -39,6 +39,7 @@ const recordImageRequest = `-- name: RecordImageRequest :exec
 insert into showtime.image_request (
     id,
     twitch_user_id,
+    screening_id,
     subject_noun_clause,
     prompt,
     created_at
@@ -47,6 +48,7 @@ insert into showtime.image_request (
     $2,
     $3,
     $4,
+    $5,
     now()
 )
 `
@@ -54,6 +56,7 @@ insert into showtime.image_request (
 type RecordImageRequestParams struct {
 	ImageRequestID    uuid.UUID
 	TwitchUserID      string
+	ScreeningID       uuid.NullUUID
 	SubjectNounClause string
 	Prompt            string
 }
@@ -62,6 +65,7 @@ func (q *Queries) RecordImageRequest(ctx context.Context, arg RecordImageRequest
 	_, err := q.db.ExecContext(ctx, recordImageRequest,
 		arg.ImageRequestID,
 		arg.TwitchUserID,
+		arg.ScreeningID,
 		arg.SubjectNounClause,
 		arg.Prompt,
 	)

--- a/gen/queries/models.go
+++ b/gen/queries/models.go
@@ -47,6 +47,8 @@ type ShowtimeImageRequest struct {
 	FinishedAt sql.NullTime
 	// Error message describing why the request completed unsuccessfully. If NULL and finished_at is not NULL, the request completed successfully.
 	ErrorMessage sql.NullString
+	// ID of the screening that was active when the image request was submitted; may be null if the request was submitted while no tape was active.
+	ScreeningID uuid.NullUUID
 }
 
 // Records the fact that a particular tape was played during a broadcast.
@@ -59,6 +61,8 @@ type ShowtimeScreening struct {
 	StartedAt time.Time
 	// Time at which the screening ended, if it's not stil ongoing.
 	EndedAt sql.NullTime
+	// Unique ID for this screening; used chiefly to associate other data with this screening.
+	ID uuid.NullUUID
 }
 
 // Details about a user who has interacted with Golden VCR at some point, either directly via goldenvcr.com or via Twitch.

--- a/internal/history/db.go
+++ b/internal/history/db.go
@@ -1,0 +1,11 @@
+package history
+
+import "github.com/google/uuid"
+
+// imageRequestSummary is the JSON format used by the GetScreeningsByBroadcastId to
+// represent the image requests that occurred during a particular screening
+type imageRequestSummary struct {
+	Id           uuid.UUID `json:"id"`
+	TwitchUserId string    `json:"twitch_user_id"`
+	Subject      string    `json:"subject"`
+}

--- a/internal/history/server.go
+++ b/internal/history/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golden-vcr/showtime/gen/queries"
 	"github.com/gorilla/mux"
+	"golang.org/x/sync/errgroup"
 )
 
 type Server struct {
@@ -79,12 +80,36 @@ func (s *Server) handleGetBroadcast(res http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// Find all screeningRows recorded within that broadcast
-	screeningRows, err := s.q.GetScreeningsByBroadcastId(req.Context(), broadcastRow.ID)
-	if err != nil {
+	// Run two queries concurrently to get the data we need for this request: all the
+	// screenings recorded within that broadcast (including image request summaries
+	// etc.), along with a lookup that maps Twitch User IDs to display names
+	screeningsChan := make(chan []queries.GetScreeningsByBroadcastIdRow, 1)
+	viewerLookupChan := make(chan []queries.GetViewerLookupForBroadcastRow, 1)
+	wg, queryCtx := errgroup.WithContext(req.Context())
+	wg.Go(func() error {
+		// Find all screening rows recorded within the broadcast
+		screeningRows, err := s.q.GetScreeningsByBroadcastId(queryCtx, broadcastRow.ID)
+		if err != nil {
+			return err
+		}
+		screeningsChan <- screeningRows
+		return nil
+	})
+	wg.Go(func() error {
+		// Get a lookup of twitch user IDs to names
+		viewerLookupRows, err := s.q.GetViewerLookupForBroadcast(queryCtx, broadcastRow.ID)
+		if err != nil {
+			return err
+		}
+		viewerLookupChan <- viewerLookupRows
+		return nil
+	})
+	if err := wg.Wait(); err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	screeningRows := <-screeningsChan
+	viewerLookupRows := <-viewerLookupChan
 
 	// Build a result struct and return it as JSON
 	screenings := make([]Screening, 0, len(screeningRows))
@@ -110,7 +135,7 @@ func (s *Server) handleGetBroadcast(res http.ResponseWriter, req *http.Request) 
 		for _, summary := range summaries {
 			imageRequests = append(imageRequests, ImageRequest{
 				Id:       summary.Id,
-				Username: fmt.Sprintf("User %s", summary.TwitchUserId),
+				Username: formatUsername(viewerLookupRows, summary.TwitchUserId),
 				Subject:  summary.Subject,
 			})
 		}
@@ -135,4 +160,13 @@ func (s *Server) handleGetBroadcast(res http.ResponseWriter, req *http.Request) 
 	if err := json.NewEncoder(res).Encode(broadcast); err != nil {
 		http.Error(res, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func formatUsername(viewerLookupRows []queries.GetViewerLookupForBroadcastRow, twitchUserId string) string {
+	for _, row := range viewerLookupRows {
+		if row.TwitchUserID == twitchUserId {
+			return row.TwitchDisplayName
+		}
+	}
+	return fmt.Sprintf("User %s", twitchUserId)
 }

--- a/internal/history/server_test.go
+++ b/internal/history/server_test.go
@@ -283,18 +283,17 @@ func (m *mockQueries) GetBroadcastById(ctx context.Context, broadcastID int32) (
 	return queries.ShowtimeBroadcast{}, sql.ErrNoRows
 }
 
-func (m *mockQueries) GetScreeningsByBroadcastId(ctx context.Context, broadcastID int32) ([]queries.ShowtimeScreening, error) {
+func (m *mockQueries) GetScreeningsByBroadcastId(ctx context.Context, broadcastID int32) ([]queries.GetScreeningsByBroadcastIdRow, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	rows := make([]queries.ShowtimeScreening, 0)
+	rows := make([]queries.GetScreeningsByBroadcastIdRow, 0)
 	for _, s := range m.screenings {
 		if s.broadcastId == broadcastID {
-			rows = append(rows, queries.ShowtimeScreening{
-				BroadcastID: s.broadcastId,
-				TapeID:      s.tapeId,
-				StartedAt:   s.startedAt,
-				EndedAt:     s.endedAt,
+			rows = append(rows, queries.GetScreeningsByBroadcastIdRow{
+				TapeID:    s.tapeId,
+				StartedAt: s.startedAt,
+				EndedAt:   s.endedAt,
 			})
 		}
 	}

--- a/internal/history/types.go
+++ b/internal/history/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golden-vcr/showtime/gen/queries"
+	"github.com/google/uuid"
 )
 
 type Queries interface {
@@ -25,7 +26,14 @@ type Broadcast struct {
 }
 
 type Screening struct {
-	TapeId    int        `json:"tapeId"`
-	StartedAt time.Time  `json:"startedAt"`
-	EndedAt   *time.Time `json:"endedAt"`
+	TapeId        int            `json:"tapeId"`
+	StartedAt     time.Time      `json:"startedAt"`
+	EndedAt       *time.Time     `json:"endedAt"`
+	ImageRequests []ImageRequest `json:"imageRequests"`
+}
+
+type ImageRequest struct {
+	Id       uuid.UUID `json:"id"`
+	Username string    `json:"username"`
+	Subject  string    `json:"subject"`
 }

--- a/internal/history/types.go
+++ b/internal/history/types.go
@@ -12,6 +12,7 @@ type Queries interface {
 	GetTapeScreeningHistory(ctx context.Context) ([]queries.GetTapeScreeningHistoryRow, error)
 	GetBroadcastById(ctx context.Context, broadcastID int32) (queries.ShowtimeBroadcast, error)
 	GetScreeningsByBroadcastId(ctx context.Context, broadcastID int32) ([]queries.GetScreeningsByBroadcastIdRow, error)
+	GetViewerLookupForBroadcast(ctx context.Context, broadcastID int32) ([]queries.GetViewerLookupForBroadcastRow, error)
 }
 
 type Summary struct {

--- a/internal/history/types.go
+++ b/internal/history/types.go
@@ -10,7 +10,7 @@ import (
 type Queries interface {
 	GetTapeScreeningHistory(ctx context.Context) ([]queries.GetTapeScreeningHistoryRow, error)
 	GetBroadcastById(ctx context.Context, broadcastID int32) (queries.ShowtimeBroadcast, error)
-	GetScreeningsByBroadcastId(ctx context.Context, broadcastID int32) ([]queries.ShowtimeScreening, error)
+	GetScreeningsByBroadcastId(ctx context.Context, broadcastID int32) ([]queries.GetScreeningsByBroadcastIdRow, error)
 }
 
 type Summary struct {

--- a/internal/imagegen/types.go
+++ b/internal/imagegen/types.go
@@ -11,6 +11,7 @@ import (
 // Queries represents the subset of database functionality required to handle image
 // generation requests
 type Queries interface {
+	GetCurrentScreening(ctx context.Context) (queries.GetCurrentScreeningRow, error)
 	RecordViewerIdentity(ctx context.Context, arg queries.RecordViewerIdentityParams) error
 	RecordImageRequest(ctx context.Context, arg queries.RecordImageRequestParams) error
 	RecordImageRequestFailure(ctx context.Context, arg queries.RecordImageRequestFailureParams) (sql.Result, error)


### PR DESCRIPTION
This PR updates the (as-yet-undocumented) broadcast history endpoint (e.g. `curl https://goldenvcr.com/api/showtime/history/1`) to include information about the image generation requests (i.e. ghost alerts) that were made during each screening.

Each `screening` record in the db now contains a UUID, and each `image_request` record may optionally refer to the screening that was active at the time of the request. This allows us to query for image requests on screening_id.